### PR TITLE
fix(display): Q² key display mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,14 @@
               <option value="">All text-generation</option>
             </select>
           </div>
+          <div class="settings-field">
+            <label for="q2-key-display-mode">Q² key display</label>
+            <select id="q2-key-display-mode">
+              <option value="q2">Q² (ABCD) - default</option>
+              <option value="cgAt">CGAT (DNA)</option>
+              <option value="hex">HEX (legacy)</option>
+            </select>
+          </div>
         </div>
 
         <button id="load-btn" disabled>Load Model</button>

--- a/src/app.ts
+++ b/src/app.ts
@@ -310,11 +310,13 @@ function initSettingsPanel(): void {
   const tokenEl = $<HTMLInputElement>('#hf-token');
   const dtypeEl = $<HTMLSelectElement>('#model-dtype');
   const libraryEl = $<HTMLSelectElement>('#filter-library');
+  const keyDisplayEl = $<HTMLSelectElement>('#q2-key-display-mode');
 
   // Restore persisted values into the form.
   tokenEl.value = currentSettings.apiToken;
   dtypeEl.value = currentSettings.dtype;
   libraryEl.value = currentSettings.filterLibrary;
+  keyDisplayEl.value = currentSettings.q2KeyDisplayMode;
 
   tokenEl.addEventListener('change', () => {
     currentSettings.apiToken = tokenEl.value.trim();
@@ -333,6 +335,11 @@ function initSettingsPanel(): void {
     saveSettings(currentSettings);
     // Re-fetch the model list with the updated library filter.
     void refreshModelList(modelSearchEl.value);
+  });
+
+  keyDisplayEl.addEventListener('change', () => {
+    currentSettings.q2KeyDisplayMode = keyDisplayEl.value as AppSettings['q2KeyDisplayMode'];
+    saveSettings(currentSettings);
   });
 }
 
@@ -706,7 +713,7 @@ export function onEmbedding(msg: EmbeddingMsg): void {
 
       // Read back packed bytes.
       const packed = new Uint8Array(kernel.memory.buffer, Q2_OUTPUT_OFFSET, n >> 2);
-      renderQ2Result(packed, key, n);
+      renderQ2Result(packed, key, n, currentSettings.q2KeyDisplayMode);
     } catch {
       // WASM unavailable — use the pure-TypeScript fallback (fp32 only).
       // This path is taken in test environments and SSR contexts.
@@ -718,7 +725,7 @@ export function onEmbedding(msg: EmbeddingMsg): void {
       const all = new Float32Array(msg.data);
       const vec = l2Normalise(all.subarray((seqLen - 1) * n, seqLen * n), n);
       const { packed, key } = q2EncodeDirect(vec, n);
-      renderQ2Result(packed, BigInt.asUintN(64, key), n);
+      renderQ2Result(packed, BigInt.asUintN(64, key), n, currentSettings.q2KeyDisplayMode);
     }
   })();
 }
@@ -892,8 +899,13 @@ export function renderEmbeddingHeatmap(
  * Appends the Q² quantisation result to the application embedding stats element.
  * Delegates to embed-panel.ts which accepts an explicit statsEl argument.
  */
-export function renderQ2Result(packed: Uint8Array, key: bigint, n: number): void {
-  renderQ2(packed, key, n, embeddingStats);
+export function renderQ2Result(
+  packed: Uint8Array,
+  key: bigint,
+  n: number,
+  mode: 'q2' | 'cgAt' | 'hex' = 'q2',
+): void {
+  renderQ2(packed, key, n, embeddingStats, mode);
 }
 
 // ─── Tab navigation ────────────────────────────────────────────────────────────

--- a/src/embed-panel.ts
+++ b/src/embed-panel.ts
@@ -15,11 +15,42 @@ export function min(arr: Float32Array): number {
   return m;
 }
 
+import { runReduce, unpackSymbols } from './q2stats.js';
+
 /** Return the maximum value in a Float32Array. */
 export function max(arr: Float32Array): number {
   let m = -Infinity;
   for (const v of arr) if (v > m) m = v;
   return m;
+}
+
+export type Q2KeyDisplayMode = 'q2' | 'cgAt' | 'hex';
+
+const Q2_SYMBOLS = ['A', 'B', 'C', 'D'] as const;
+const CGAT_SYMBOLS = ['G', 'A', 'C', 'T'] as const;
+
+export function formatQ2KeyDisplay(
+  packed: Uint8Array,
+  n: number,
+  key: bigint,
+  mode: Q2KeyDisplayMode,
+): string {
+  const keyHex = key.toString(16).padStart(16, '0');
+
+  if (mode === 'hex') {
+    return `0x${keyHex}`;
+  }
+
+  const symbols = unpackSymbols(packed, n);
+  const transitions = runReduce(symbols);
+
+  const mapping = mode === 'q2' ? Q2_SYMBOLS : CGAT_SYMBOLS;
+  const label = mode === 'q2' ? 'Q²' : 'CGAT';
+
+  const rendered = transitions.map((s) => mapping[s]).join('');
+  const capped = rendered.length > 32 ? `${rendered.slice(0, 32)}…` : rendered;
+
+  return `${label}:${capped} (0x${keyHex})`;
 }
 
 /**
@@ -88,14 +119,16 @@ export function renderQ2Result(
   key: bigint,
   n: number,
   statsEl: HTMLParagraphElement,
+  mode: Q2KeyDisplayMode = 'q2',
 ): void {
   // Hex dump of the first 8 bytes (32 symbols) for display.
   const hexBytes = Array.from(packed.slice(0, 8))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
   const ellipsis = packed.length > 8 ? '…' : '';
-  // Display the key as a zero-padded 16-hex-digit unsigned 64-bit value.
-  const keyHex = key.toString(16).padStart(16, '0');
+
+  const keyDisplay = formatQ2KeyDisplay(packed, n, key, mode);
+
   statsEl.textContent +=
-    `\nQ²: [${hexBytes}${ellipsis}] (${n >> 2} bytes, ${n} dims)  key=0x${keyHex}`;
+    `\nQ²: [${hexBytes}${ellipsis}] (${n >> 2} bytes, ${n} dims)  key=${keyDisplay}`;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,8 @@
 
 import type { Dtype, FilterLibrary } from './types.js';
 
+import type { Q2KeyDisplayMode } from './types.js';
+
 export interface AppSettings {
   /** Optional HuggingFace API token (private models, higher rate limits). */
   apiToken: string;
@@ -14,12 +16,15 @@ export interface AppSettings {
   dtype: Dtype;
   /** Library filter tag sent to the HF Hub API. */
   filterLibrary: FilterLibrary;
+  /** Q² transition key display mode in the embedding panel. */
+  q2KeyDisplayMode: Q2KeyDisplayMode;
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
   apiToken: '',
   dtype: 'q4',
   filterLibrary: 'transformers.js',
+  q2KeyDisplayMode: 'q2',
 };
 
 const SETTINGS_KEY = 'q2_settings';

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,9 @@ export type Dtype = 'q4' | 'q8' | 'fp16' | 'fp32';
  */
 export type FilterLibrary = 'transformers.js' | 'onnx' | '';
 
+/** Q² transition key display mode in the embedding panel. */
+export type Q2KeyDisplayMode = 'q2' | 'cgAt' | 'hex';
+
 // ─── Main thread → Worker ────────────────────────────────────────────────────
 
 export interface LoadModelMsg {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -57,6 +57,11 @@ function setupDom() {
         <option value="onnx">onnx</option>
         <option value="">All</option>
       </select>
+      <select id="q2-key-display-mode">
+        <option value="q2" selected>q2</option>
+        <option value="cgAt">cgAt</option>
+        <option value="hex">hex</option>
+      </select>
       <button id="load-btn" disabled>Load</button>
     </div>
 
@@ -356,10 +361,10 @@ describe('app.ts helpers and DOM integration', () => {
     stats.textContent = 'Shape: [1 × 8]  dtype=fp32  min=0.000  max=1.000';
 
     const packed = new Uint8Array([0xAA, 0xAA]); // D D D D D D D D (all strong+)
-    app.renderQ2Result(packed, 0xdd8c000000000000n, 8);
+    app.renderQ2Result(packed, 0xdd8c000000000000n, 8, 'q2');
 
     expect(stats.textContent).toContain('Q²:');
-    expect(stats.textContent).toContain('key=0x');
+    expect(stats.textContent).toContain('key=Q²:');
     expect(stats.textContent).toContain('2 bytes');
   });
 
@@ -465,6 +470,15 @@ describe('app.ts helpers and DOM integration', () => {
     expect(workerRef.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'load', dtype: 'q8' }),
     );
+  });
+
+  it('changing q2-key-display-mode persists the setting', () => {
+    const keyModeEl = document.querySelector('#q2-key-display-mode') as HTMLSelectElement;
+    keyModeEl.value = 'cgAt';
+    keyModeEl.dispatchEvent(new Event('change'));
+
+    const loadedSettings = app.loadSettings();
+    expect(loadedSettings.q2KeyDisplayMode).toBe('cgAt');
   });
 
   it('switchTab changes active tab and shows correct panel', () => {


### PR DESCRIPTION
Adds Q² key display mode option to embedding panel with modes q2 (default), cgAt, and hex, persisted in settings. Includes unit tests and has passed vitest.